### PR TITLE
Fixed metadata.rb to allow uploads using Berkshelf

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,7 @@
   "name": "s3_file",
   "description": "Installs/Configures s3_file LWRP",
   "long_description": "= DESCRIPTION:\nAn LWRP that can be used to fetch files from S3.\n\nI created this LWRP to solve the chicken-and-egg problem of fetching files from S3 on the first Chef run on a newly provisioned machine. Ruby libraries that are installed on that first run are not available to Chef during the run, so I couldn't use a library like Fog to get what I needed from S3.\n\nThis LWRP has no dependencies beyond the Ruby standard library, so it can be used on the first run of Chef.\n\n= REQUIREMENTS:\nAn Amazon Web Services account and something in S3 to fetch.\n\n= USAGE:\ns3_file acts like other file resources.  The only supported action is :create, which is the default.\n\nAttribute Parameters:\n \n* `aws_access_key_id` - your AWS access key id.\n* `aws_secret_access_key` - your AWS secret access key.\n* `bucket` - the bucket to pull from.\n* `remote_path` - the S3 key to pull.\n\nExample:\n\n    s3_file \"/tmp/somefile\" do\n    \tremote_path \"/my/s3/key\"\n    \tbucket \"my-s3-bucket\"\n    \taws_access_key_id \"mykeyid\"\n    \taws_aws_secret_access_key \"mykey\"\n    \taction :create\n    end\n\n\n",
+  "maintainer": "Brandon Adams",
   "maintainer_email": "brandon.adams@me.com",
   "license": "MIT",
   "platforms": {
@@ -24,5 +25,5 @@
   },
   "recipes": {
   },
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,7 @@
-maintainer       "YOUR_COMPANY_NAME"
+name             "s3_file"
+maintainer       "Brandon Adams"
 maintainer_email "brandon.adams@me.com"
 license          "MIT"
 description      "Installs/Configures s3_file LWRP"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
-version          "1.0"
+version          "1.0.1"


### PR DESCRIPTION
If using [Berkshelf](http://berkshelf.com) to manage local cookbooks on a Chef Workstation, uploading to the Chef server via `berks upload` will fail parsing the metadata.rb for s3_file as 'name' is missing. This change adds metadata.name to metadata.rb and updates some of the information there. 
