### PR TITLE
Avoid re-download for multi-part uploads

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -8,6 +8,10 @@ This LWRP has no dependencies beyond the Ruby standard library, so it can be use
 = REQUIREMENTS:
 An Amazon Web Services account and something in S3 to fetch.
 
+Multi-part S3 uploads do not put the MD5 of the content in the ETag header. If x-amz-meta-digest is provided in User-Defined Metadata on the S3 Object it is processed as if it were a Digest header (RFC 3230).
+
+The MD5 of the local file will be checked against the MD5 from x-amz-meta-digest if it is present.  It not it will check against the ETag.  If there is no match or the local file is absent it will be downloaded.
+
 = USAGE:
 s3_file acts like other file resources.  The only supported action is :create, which is the default.
 

--- a/libraries/s3_file.rb
+++ b/libraries/s3_file.rb
@@ -5,32 +5,37 @@ require 'base64'
 
 module S3FileLib
   def self.get_md5_from_s3(bucket,path,aws_access_key_id,aws_secret_access_key)
-    now = Time.now().utc.strftime('%a, %d %b %Y %H:%M:%S GMT')
-    string_to_sign = "HEAD\n\n\n%s\n/%s%s" % [now,bucket,path]
-
-    digest = digest = OpenSSL::Digest::Digest.new('sha1')
-    signed = OpenSSL::HMAC.digest(digest, aws_secret_access_key, string_to_sign)
-    signed_base64 = Base64.encode64(signed)
-
-    auth_string = 'AWS %s:%s' % [aws_access_key_id,signed_base64]
-
-    response = RestClient.head('https://%s.s3.amazonaws.com%s' % [bucket,path], :date => now, :authorization => auth_string)
-    
-    return response.headers[:etag].gsub('"','')
+    return get_digests_from_s3(bucket,path,aws_access_key_id,aws_secret_access_key)["md5"]
   end
   
+  def self.get_digests_from_s3(bucket,path,aws_access_key_id,aws_secret_access_key)
+    now, auth_string = get_s3_auth("HEAD", bucket,path,aws_access_key_id,aws_secret_access_key)
+    response = RestClient.head('https://%s.s3.amazonaws.com%s' % [bucket,path], :date => now, :authorization => auth_string)
+    
+    etag = response.headers[:etag].gsub('"','')
+    digest = response.headers[:x_amz_meta_digest]
+    digests = digest.nil? ? {} : Hash[digest.split(",").map {|a| a.split("=")}]
+
+    return {"md5" => etag}.merge(digests)
+  end
+
   def self.get_from_s3(bucket,path,aws_access_key_id,aws_secret_access_key)    
-    now = Time.now().utc.strftime('%a, %d %b %Y %H:%M:%S GMT')
-    string_to_sign = "GET\n\n\n%s\n/%s%s" % [now,bucket,path]
-
-    digest = digest = OpenSSL::Digest::Digest.new('sha1')
-    signed = OpenSSL::HMAC.digest(digest, aws_secret_access_key, string_to_sign)
-    signed_base64 = Base64.encode64(signed)
-
-    auth_string = 'AWS %s:%s' % [aws_access_key_id,signed_base64]
-
+    now, auth_string = get_s3_auth("GET", bucket,path,aws_access_key_id,aws_secret_access_key)
     response = RestClient.get('https://%s.s3.amazonaws.com%s' % [bucket,path], :date => now, :authorization => auth_string)
 
     return response.body
+  end
+
+  def self.get_s3_auth(method, bucket,path,aws_access_key_id,aws_secret_access_key)
+    now = Time.now().utc.strftime('%a, %d %b %Y %H:%M:%S GMT')
+    string_to_sign = "#{method}\n\n\n%s\n/%s%s" % [now,bucket,path]
+
+    digest = digest = OpenSSL::Digest::Digest.new('sha1')
+    signed = OpenSSL::HMAC.digest(digest, aws_secret_access_key, string_to_sign)
+    signed_base64 = Base64.encode64(signed)
+
+    auth_string = 'AWS %s:%s' % [aws_access_key_id,signed_base64]
+
+    [now,auth_string]
   end
 end


### PR DESCRIPTION
Multi-part S3 uploads do not put the MD5 of the content in the ETag header. In
order to allow users to prevent re-download of these objects I added support
for User-Defined Metadata that provides the hash. If x-amz-meta-digest is
provided it is processed as if it were a Digest header (RFC 3230).

For example an S3 Object might have the following properties:
ETag: 680835367a1c3033acedf7469692b568-2
x-amz-meta-digest: md5=79a5b8d7c02d8debba0432b6b48e9baf,SHA=7c31939ca9adfc3fd989e2c8af5ab8fe589aa795

The MD5 of the local file will be checked against the MD5 from
x-amz-meta-digest if it is present.  It will take precedence over the ETag.

I also refactored methods to share common time and auth string generation.

Fixed the handling of digest being nil.  Just needed a quick ternary to return an empty hash.  It was the lowest ugliness solution I could think of :)
