### PR TITLE
HTTP Proxy Support

### DIFF
--- a/libraries/s3_file.rb
+++ b/libraries/s3_file.rb
@@ -4,6 +4,8 @@ require 'openssl'
 require 'base64'
 
 module S3FileLib
+  RestClient.proxy = ENV['http_proxy']
+
   def self.build_headers(date, authorization, token)
     headers = {
       :date => date,


### PR DESCRIPTION
If the 'http_proxy' environment is set it will be used by requests to S3.

This allows things like --bootstrap-proxy to work as expected.
