### PR TITLE
Use file resource to set file permissions on windows

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -61,8 +61,12 @@ action :create do
     group = new_resource.group || ENV['user']
     
     ::FileUtils.mv response.file.path, new_resource.path
-    ::FileUtils.chown owner, group, [ new_resource.path ]
-    ::FileUtils.chmod mode, [ new_resource.path ]
+    file new_resource.path do
+      owner owner
+      group group
+      mode mode
+      action :create
+    end
     
     @new_resource.updated_by_last_action(true)
   end


### PR DESCRIPTION
Reasoning being the fix for https://github.com/adamsb6/s3_file/issues/15 uses FileUtils#chown and #chmod which call Etc.getpwnam() which can't be used on Windows.
FileUtils.mv is fine for putting it in place, use Chef's `file` resource to set permissions.
