### PR TITLE
notify "immediately" causes notified resource to run too soon

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -1,26 +1,22 @@
-#include S3File
-
 require 'digest/md5'
 require 'rest-client'
 require 'json'
 
+use_inline_resources
+
 action :create do
-  new_resource = @new_resource
   download = true
-  
+
   # handle key specified without leading slash
-  remote_path = new_resource.remote_path
-  if remote_path.chars.first != '/'
-    remote_path = "/#{remote_path}"
-  end
-  
+  remote_path = ::File.join('', new_resource.remote_path)
+
   # we need credentials to be mutable
   aws_access_key_id = new_resource.aws_access_key_id
   aws_secret_access_key = new_resource.aws_secret_access_key
   token = new_resource.token
-  
+
   # if credentials not set, try instance profile
-  if new_resource.aws_access_key_id.nil? and new_resource.aws_secret_access_key.nil? and new_resource.token.nil?
+  if aws_access_key_id.nil? && aws_secret_access_key.nil? && token.nil?
     instance_profile_base_url = 'http://169.254.169.254/latest/meta-data/iam/security-credentials/'
     begin
       instance_profiles = RestClient.get(instance_profile_base_url)
@@ -29,45 +25,40 @@ action :create do
     end
     instance_profile_name = instance_profiles.split.first
     instance_profile = JSON.load(RestClient.get(instance_profile_base_url + instance_profile_name))
-    
+
     aws_access_key_id = instance_profile['AccessKeyId']
     aws_secret_access_key = instance_profile['SecretAccessKey']
     token = instance_profile['Token']
   end
-    
-  if ::File.exists? new_resource.path
+
+  if ::File.exists?(new_resource.path)
     s3_md5 = S3FileLib::get_md5_from_s3(new_resource.bucket, remote_path, aws_access_key_id, aws_secret_access_key, token)
-    
-    current_md5 = Digest::MD5.hexdigest(::File.read(new_resource.path))
-    
+    local_md5 = Digest::MD5.hexdigest(::File.read(new_resource.path))
+
     Chef::Log.debug "md5 of S3 object is #{s3_md5}"
-    Chef::Log.debug "md5 of local object is #{current_md5}"
-    
-    if current_md5 == s3_md5 then
+    Chef::Log.debug "md5 of local object is #{local_md5}"
+
+    if local_md5 == s3_md5
       Chef::Log.debug 'Skipping download, md5sum of local file matches file in S3.'
       download = false
     end
   end
-  
+
   if download
     response = S3FileLib::get_from_s3(new_resource.bucket, remote_path, aws_access_key_id, aws_secret_access_key, token)
 
-    # not simply using the file resource here because we would have to buffer whole file into memory in order to set content
-    # this solves https://github.com/adamsb6/s3_file/issues/15
-    mode = new_resource.mode || 0644
-    mode = mode.is_a?(String) ? mode.to_i(8) : mode
-    
-    owner = new_resource.owner || ENV['user']
-    group = new_resource.group || ENV['user']
-    
-    ::FileUtils.mv response.file.path, new_resource.path
-    file new_resource.path do
-      owner owner
-      group group
-      mode mode
-      action :create
-    end
-    
-    @new_resource.updated_by_last_action(true)
+    # not simply using the file resource here because we would have to buffer
+    # whole file into memory in order to set content this solves
+    # https://github.com/adamsb6/s3_file/issues/15
+    ::FileUtils.mv(response.file.path, new_resource.path)
   end
+
+  f = file new_resource.path do
+    action :create
+    owner new_resource.owner || ENV['user']
+    group new_resource.group || ENV['user']
+    mode new_resource.mode || '0644'
+  end
+
+  new_resource.updated_by_last_action(download || f.updated_by_last_action?)
 end


### PR DESCRIPTION
I noticed that a "notify immediately" action on this resource causes the other resource to run _before_ file permissions/ownership are properly set by the `s3_file` resource.

Example:

``` ruby
s3_file File.join('/usr/lib/jvm/java-6-openjdk-amd64/', jai_file) do
  notifies              :run, "execute[install #{jai}]", :immediately
  remote_path           jai_file
  bucket                BUCKET
  mode                  '0755'
  aws_access_key_id     ID
  aws_secret_access_key KEY
end

execute "install #{jai}" do
  action  :nothing
  cwd     '/usr/lib/jvm/java-6-openjdk-amd64/'
  command "./#{jai_file}"
end
```

This will cause:

```
[2014-02-09T10:32:05+00:00] ERROR: execute[install jai_imageio-1_1-lib]
(myapp::app line 37) had an error: Errno::EACCES: Permission denied - ./jai_imageio-1_1-lib-linux-amd64-jdk.bin
```

When removing `:immediately` (delaying the action), it runs normally.

I haven't found the issue yet in this cookbook, though I presume it has something to do with calling the file resource.

What I did notice while looking at this resource, the `file` resource is only called if a file is freshly downloaded. I would expect that resource the run every time, since it involves file ownership, which could change even if the file is present. Also the file resource is capable of figuring out when to run and when not to, so it's safe to run every time this resource is called.
