### PR TITLE
Adds version constraint on rest-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2015-06-03 version TBD
+======================
+  * Adds version constraint on rest-client to 1.7.3.
+  * Adds a cookbook attribute for overwriting the rest-client gem version.
+
 2015-03-20 version 2.5.3
 ========================
   * Fix deprecated digest call.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,1 @@
+default['s3_file']['rest-client']['version'] = '1.7.3'

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -1,3 +1,4 @@
-chef_gem "rest-client" do
+chef_gem 'rest-client' do
+  version node['s3_file']['rest-client']['version']
   action :install
 end


### PR DESCRIPTION
Resolves #46 

I'm open to another version of the rest-client but 1.7.3 kept our environment sane.