### PR TITLE
Sigv4 support

### DIFF
--- a/libraries/s3_file.rb
+++ b/libraries/s3_file.rb
@@ -130,6 +130,7 @@ module S3FileLib
         url = uri.to_s
         retry
       rescue => e
+        raise e unless e.respond_to? :response
         if attempts < retries
           Chef::Log.warn e.response
           next

--- a/libraries/s3_file.rb
+++ b/libraries/s3_file.rb
@@ -78,7 +78,7 @@ module S3FileLib
     yield(region)
   rescue client::BadRequest => e
     if region.nil?
-      region = e.response["x-amz-region"]
+      region = e.response.headers[:x_amz_region]
       raise if region.nil?
       yield(region)
     else

--- a/libraries/s3_file.rb
+++ b/libraries/s3_file.rb
@@ -123,6 +123,12 @@ module S3FileLib
       begin
         response = do_request("GET", url, bucket, path, aws_access_key_id, aws_secret_access_key, token, region)
         break
+      rescue client::MovedPermanently, client::Found, client::TemporaryRedirect => e
+        uri = URI.parse(e.response.header['location'])
+        path = uri.path
+        uri.path = ""
+        url = uri.to_s
+        retry
       rescue => e
         if attempts < retries
           Chef::Log.warn e.response


### PR DESCRIPTION
This will implement the AWS SigV4 signature model to work with the eu-central-1 region.

I implemented not the full SigV4 but only a subset dedicated to the required download from S3 use-case.

SigV4 requires the region for signing the request. But the old s3_file API doesn't allow to specify the region. For this reason the code will first try to do a normal request with the old SigV2 and if this fails it will look at the `x-amz-region` header of the error response to get the region and retry the same request with SigV4 in this region. This is not ideal so I added a region parameter to `get_from_s3` etc to be able to pass the region and don't rely on this retry. But for always using SigV4 it would require a API change in the resource.

This should fix #52 