### PR TITLE
Update s3_file.rb to remove 'no_proxy'

### DIFF
--- a/libraries/s3_file.rb
+++ b/libraries/s3_file.rb
@@ -216,7 +216,6 @@ module S3FileLib
     require 'rest-client'
     RestClient.proxy = ENV['http_proxy']
     RestClient.proxy = ENV['https_proxy']
-    RestClient.proxy = ENV['no_proxy']
     RestClient
   end
 end


### PR DESCRIPTION
The setting of 'no_proxy' is not an option within rest-client, nor the underlying Net::HTTP, so removing this option as it sets an invalid proxy value if the environment variable is configured.

Fixes https://github.com/adamsb6/s3_file/issues/87 in the event of 'no_proxy' being set, as the functionality is not available within rest-client.
