### PR TITLE
Removing metadata.json from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-metadata.json
 .kitchen.local.yml
 .kitchen
 .s3.yml


### PR DESCRIPTION
This was causing OpsWorks to report `Could not satisfy version constraints for: s3_file`