### PR TITLE
URL encoding and s3 public bucket support

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,5 +2,4 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 's3_file_test', :path => 'test/fixtures/cookbooks/s3_file_test'
-
+cookbook 's3_file_test', path: 'test/fixtures/cookbooks/s3_file_test'

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Attribute Parameters:
 * `token` - token used for temporary IAM credentials. (optional)
 * `bucket` - the bucket to pull from.
 * `s3_url` - Custom S3 URL. If specified this URL *must* include the bucket name at the end. (optional)
+* `public_bucket` - Set to true if the bucket is public, defaults to false (optional)
 * `remote_path` - the S3 key to pull.
 * `owner` - the owner of the file. (optional)
 * `group` - the group owner of the file. (optional)

--- a/libraries/s3_file.rb
+++ b/libraries/s3_file.rb
@@ -4,9 +4,9 @@ require 'base64'
 
 module S3FileLib
 
-
   module SigV2
-    def self.sign(request, bucket, path, aws_access_key_id, aws_secret_access_key, token)
+  def self.sign(request, bucket, path, *args)
+      token = args[2] if args[2]
       now = Time.now().utc.strftime('%a, %d %b %Y %H:%M:%S GMT')
       string_to_sign = "#{request.method}\n\n\n%s\n" % [now]
 
@@ -15,10 +15,10 @@ module S3FileLib
       string_to_sign += "/%s%s" % [bucket,path]
 
       digest = OpenSSL::Digest.new('sha1')
-      signed = OpenSSL::HMAC.digest(digest, aws_secret_access_key, string_to_sign)
+      signed = OpenSSL::HMAC.digest(digest, args[1], string_to_sign)
       signed_base64 = Base64.encode64(signed)
 
-      auth_string = 'AWS %s:%s' % [aws_access_key_id, signed_base64]
+      auth_string = 'AWS %s:%s' % [args[0], signed_base64]
 
       request["date"] = now
       request["authorization"] = auth_string.strip
@@ -28,16 +28,17 @@ module S3FileLib
   end
 
   module SigV4
-    def self.sigv4(string_to_sign, aws_secret_access_key, region, date, serviceName)
-      k_date    = OpenSSL::HMAC.digest("sha256", "AWS4" + aws_secret_access_key, date)
-      k_region  = OpenSSL::HMAC.digest("sha256", k_date, region)
+    def self.sigv4(string_to_sign, *args, date, serviceName, public_bucket)
+      k_date    = OpenSSL::HMAC.digest("sha256", "AWS4" + args[0], date)
+      k_region  = OpenSSL::HMAC.digest("sha256", k_date, args[1])
       k_service = OpenSSL::HMAC.digest("sha256", k_region, serviceName)
       k_signing = OpenSSL::HMAC.digest("sha256", k_service, "aws4_request")
 
       OpenSSL::HMAC.hexdigest("sha256", k_signing, string_to_sign)
     end
 
-    def self.sign(request, params, region, aws_access_key_id, aws_secret_access_key, token = nil)
+    def self.sign(request, params, *args)
+      token = args[3] if args[3]
       url = URI.parse(params[:url])
       content = request.body || ""
 
@@ -60,11 +61,11 @@ module S3FileLib
       signed_headers = request.each_name.map(&:downcase).sort.join(";")
 
       canonical_request = [request.method, url.path, canonical_query_string, canonical_headers, signed_headers, body_digest].join("\n")
-      scope = format("%s/%s/%s/%s", date, region, service, "aws4_request")
-      credential = [aws_access_key_id, scope].join("/")
+      scope = format("%s/%s/%s/%s", date, args[0], service, "aws4_request")
+      credential = [args[1], scope].join("/")
 
       string_to_sign = "#{algorithm}\n#{time}\n#{scope}\n#{Digest::SHA256.hexdigest(canonical_request)}"
-      signed_hex = sigv4(string_to_sign, aws_secret_access_key, region, date, service)
+      signed_hex = sigv4(string_to_sign, args[2], args[0], date, service)
       auth_string = "#{algorithm} Credential=#{credential}, SignedHeaders=#{signed_headers}, Signature=#{signed_hex}"
 
       request["Authorization"] = auth_string
@@ -86,16 +87,19 @@ module S3FileLib
     end
   end
 
-  def self.do_request(method, url, bucket, path, aws_access_key_id, aws_secret_access_key, token, region)
+  def self.do_request(method, url, bucket, path, *args, public_bucket)
+    region = args[3]
     url = build_endpoint_url(bucket, region) if url.nil?
 
     with_region_detect(region) do |real_region|
       client.reset_before_execution_procs
       client.add_before_execution_proc do |request, params|
-        if real_region.nil?
-          SigV2.sign(request, bucket, path, aws_access_key_id, aws_secret_access_key, token)
-        else
-          SigV4.sign(request, params, real_region, aws_access_key_id, aws_secret_access_key, token)
+        if !public_bucket
+          if real_region.nil?
+            SigV2.sign(request, bucket, path, args[0], args[1], args[2])
+          else
+            SigV4.sign(request, params, real_region, args[0], args[1], args[2])
+          end
         end
       end
       client::Request.execute(:method => method, :url => "#{url}#{path}", :raw_response => true)
@@ -116,12 +120,16 @@ module S3FileLib
     end
   end
 
-  def self.get_md5_from_s3(bucket, url, path, aws_access_key_id, aws_secret_access_key, token, region = nil)
-    get_digests_from_s3(bucket, url, path, aws_access_key_id, aws_secret_access_key, token, region)["md5"]
+  def self.get_md5_from_s3(bucket, url, path, *args, public_bucket)
+    if public_bucket
+      get_digests_from_s3(bucket, url, path)["md5"]
+    else
+      get_digests_from_s3(bucket, url, path, args[0], args[1], args[2], args[3])["md5"]
+    end
   end
 
-  def self.get_digests_from_s3(bucket,url,path,aws_access_key_id,aws_secret_access_key,token, region)
-    response = do_request("HEAD", url, bucket, path, aws_access_key_id, aws_secret_access_key, token, region)
+  def self.get_digests_from_s3(bucket, url, path, *args)
+    response = do_request("HEAD", url, bucket, path, args[0], args[1], args[2], args[3])
 
     etag = response.headers[:etag].gsub('"','')
     digest = response.headers[:x_amz_meta_digest]
@@ -130,12 +138,18 @@ module S3FileLib
     return {"md5" => etag}.merge(digests)
   end
 
-  def self.get_from_s3(bucket, url, path, aws_access_key_id, aws_secret_access_key, token, region = nil)
+  def self.get_from_s3(bucket, url, path, *args, public_bucket)
     response = nil
     retries = 5
     for attempts in 0..retries
       begin
-        response = do_request("GET", url, bucket, path, aws_access_key_id, aws_secret_access_key, token, region)
+        if public_bucket
+          puts 'public'
+          response = do_request("GET", url, bucket, path, public_bucket)
+        else
+          puts 'private'
+          response = do_request("GET", url, bucket, path, args[0], args[1], args[2], args[3], public_bucket)
+        end
         return response
         # break
       rescue client::MovedPermanently, client::Found, client::TemporaryRedirect => e

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "brandon.adams@me.com"
 license          "MIT"
 description      "Installs/Configures s3_file LWRP"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.7"
+version          "2.8.0"

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -1,15 +1,23 @@
 require 'digest/md5'
 require 'json'
+require 'cgi'
 
 use_inline_resources
 
 action :create do
   @run_context.include_recipe 's3_file::dependencies'
-  client = S3FileLib::client
+  client = S3FileLib.client
   download = true
 
   # handle key specified without leading slash
-  remote_path = ::File.join('', new_resource.remote_path)
+  remote_path_unencoded = ::File.join('', new_resource.remote_path)
+  # adding code for encoding the remote_path and file name in case 
+  # of files/keys containing characters such as +
+  remote_path = []
+  remote_path_unencoded.split('/').each do |enc|
+    remote_path << CGI.escape(enc)
+  end
+  remote_path = remote_path.join('/')
 
   # we need credentials to be mutable
   aws_access_key_id = new_resource.aws_access_key_id
@@ -19,24 +27,30 @@ action :create do
 
   # if credentials not set, try instance profile
   if aws_access_key_id.nil? && aws_secret_access_key.nil? && token.nil?
-    instance_profile_base_url = 'http://169.254.169.254/latest/meta-data/iam/security-credentials/'
-    begin
-      instance_profiles = client.get(instance_profile_base_url)
-    rescue client::ResourceNotFound, Errno::ETIMEDOUT # we can either 404 on an EC2 instance, or timeout on non-EC2
-      raise ArgumentError.new 'No credentials provided and no instance profile on this machine.'
-    end
-    instance_profile_name = instance_profiles.split.first
-    instance_profile = JSON.load(client.get(instance_profile_base_url + instance_profile_name))
+    if new_resource.public_bucket
+      aws_access_key_id = ''
+      aws_secret_access_key = ''
+      token = ''
+    else
+      instance_profile_base_url = 'http://169.254.169.254/latest/meta-data/iam/security-credentials/'
+      begin
+        instance_profiles = client.get(instance_profile_base_url)
+      rescue client::ResourceNotFound, Errno::ETIMEDOUT # set 404 on an EC2 instance
+        raise ArgumentError.new 'No credentials provided and no instance profile on this machine.'
+      end
+      instance_profile_name = instance_profiles.split.first
+      instance_profile = JSON.load(client.get(instance_profile_base_url + instance_profile_name))
 
-    aws_access_key_id = instance_profile['AccessKeyId']
-    aws_secret_access_key = instance_profile['SecretAccessKey']
-    token = instance_profile['Token']
+      aws_access_key_id = instance_profile['AccessKeyId']
+      aws_secret_access_key = instance_profile['SecretAccessKey']
+      token = instance_profile['Token']
+    end
   end
 
   if ::File.exists?(new_resource.path)
     if decryption_key.nil?
       if new_resource.decrypted_file_checksum.nil?
-        s3_md5 = S3FileLib::get_md5_from_s3(new_resource.bucket, new_resource.s3_url, remote_path, aws_access_key_id, aws_secret_access_key, token)
+        s3_md5 = S3FileLib::get_md5_from_s3(new_resource.bucket, new_resource.s3_url, remote_path, aws_access_key_id, aws_secret_access_key, token, new_resource.public_bucket)
 
         if S3FileLib::verify_md5_checksum(s3_md5, new_resource.path)
           Chef::Log.debug 'Skipping download, md5sum of local file matches file in S3.'
@@ -62,7 +76,7 @@ action :create do
   end
 
   if download
-    response = S3FileLib::get_from_s3(new_resource.bucket, new_resource.s3_url, remote_path, aws_access_key_id, aws_secret_access_key, token)
+    response = S3FileLib::get_from_s3(new_resource.bucket, new_resource.s3_url, remote_path, aws_access_key_id, aws_secret_access_key, token, new_resource.public_bucket)
 
     # not simply using the file resource here because we would have to buffer
     # whole file into memory in order to set content this solves

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -5,6 +5,7 @@ attribute :bucket, :kind_of => String
 attribute :aws_access_key_id, :kind_of => String, :default => nil
 attribute :aws_secret_access_key, :kind_of => String, :default => nil
 attribute :s3_url, :kind_of => String, :default => nil
+attribute :public_bucket, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :token, :kind_of => String, :default => nil
 attribute :owner, :kind_of => [String, NilClass], :default => nil
 attribute :group, :kind_of => [String, NilClass], :default => nil


### PR DESCRIPTION
Added encoding of s3 bucket keys as the cookbook used to fail for file names conatianing characters such as `+`. 

Added support for downloading from public s3 buckets in the case of no access keys  being provided.