### PR TITLE
Fix region handling in GovCloud, with explicit region or improved auto-detection

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -4,6 +4,7 @@ attribute :remote_path, :kind_of => String
 attribute :bucket, :kind_of => String
 attribute :aws_access_key_id, :kind_of => String, :default => nil
 attribute :aws_secret_access_key, :kind_of => String, :default => nil
+attribute :aws_region, :kind_of => String, :default => nil
 attribute :s3_url, :kind_of => String, :default => nil
 attribute :token, :kind_of => String, :default => nil
 attribute :owner, :kind_of => [String, NilClass], :default => nil


### PR DESCRIPTION
Due to the partition between the `aws` and `aws-us-gov` namespaces, the current method of auto-detecting the region of an S3 bucket will *never* work *unless* you start out in a govcloud region the first place.  Requests to `s3.amazonaws.com` will not recognize govcloud credentials, because those credentials only exist in the `aws-us-gov` partition, not the `aws` partition.

Luckily, on EC2 instances, there is already a way to auto-detect the region from the instance-identity document, which I've added to this PR.

Finally, in case you are not on an EC2 instance but need to access a gov-cloud S3 bucket, I've added the ability to explicitly specify your `aws_region` in the `s3_file` resource.