### PR TITLE
deault provider :: Log credential received flags

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -17,6 +17,7 @@ action :create do
   token = new_resource.token
   decryption_key = new_resource.decryption_key
 
+  Chef::Log.info("credentials received [aws_access_key_id:%s, aws_secret_access_key:%s, token:%s]" % [!aws_access_key_id.nil?, !aws_secret_access_key.nil?, !token.nil?])
   # if credentials not set, try instance profile
   if aws_access_key_id.nil? && aws_secret_access_key.nil? && token.nil?
     instance_profile_base_url = 'http://169.254.169.254/latest/meta-data/iam/security-credentials/'


### PR DESCRIPTION
After two days trying to identify the problem of "no implicit conversion of nil into String (TypeError)", I put this log to evidence the application parameters that were missing.