### PR TITLE
Fix Cookbook for EC2 Instance Metadata Service IMDSV2 configuration (SSRF patch)

### DIFF
--- a/libraries/s3_file.rb
+++ b/libraries/s3_file.rb
@@ -120,7 +120,6 @@ module S3FileLib
     end
   end
 
-  s3_etag = S3FileLib::get_md5_from_s3(new_resource.bucket, new_resource.s3_url, remote_path, aws_access_key_id, aws_secret_access_key, token, public_bucket: new_resource.public_bucket)
   def self.get_md5_from_s3(bucket, url, path, *args, public_bucket: nil)
     if public_bucket
       get_digests_from_s3(bucket, url, path, public_bucket: public_bucket)["md5"]

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -56,7 +56,7 @@ action :create do
   end
 
   if ::File.exists?(new_resource.path)
-    s3_etag = S3FileLib::get_md5_from_s3(new_resource.bucket, new_resource.s3_url, remote_path, aws_access_key_id, aws_secret_access_key, token, new_resource.public_bucket)
+    s3_etag = S3FileLib::get_md5_from_s3(new_resource.bucket, new_resource.s3_url, remote_path, aws_access_key_id, aws_secret_access_key, token, public_bucket: new_resource.public_bucket)
 
     if decryption_key.nil?
       if new_resource.decrypted_file_checksum.nil?
@@ -94,7 +94,7 @@ action :create do
   end
 
   if download
-    response = S3FileLib::get_from_s3(new_resource.bucket, new_resource.s3_url, remote_path, aws_access_key_id, aws_secret_access_key, token,region, new_resource.verify_md5, new_resource.public_bucket)
+    response = S3FileLib::get_from_s3(new_resource.bucket, new_resource.s3_url, remote_path, aws_access_key_id, aws_secret_access_key, token, region: region, verify_md5: new_resource.verify_md5, public_bucket: new_resource.public_bucket)
 
     # not simply using the file resource here because we would have to buffer
     # whole file into memory in order to set content this solves


### PR DESCRIPTION
# Agenda
Update all service calls to EC2 metadata to use IMDSV2 spec: 
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html

EC2 metadata service IMDSV1 introduced quite a few vulnerabilities: https://hackerone.com/reports/508459

# Fix 
- [X] add proc to retrieve token (could also have been on the client but not used elsewhere)
- [X] use retrieved token (single hop? -> EC2 Configuration) to call metadata service

# Rollout 
If this doesn't get rolled out Macroplant may maintain a publicly available version.  
